### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/devuss/25a1e572-fed0-4ac7-a9b2-6b7d6d4b0442/493856a7-6dbd-42fe-9371-6fefce221380/_apis/work/boardbadge/36a0bd4f-90cd-46e7-9608-49a935c43e08)](https://dev.azure.com/devuss/25a1e572-fed0-4ac7-a9b2-6b7d6d4b0442/_boards/board/t/493856a7-6dbd-42fe-9371-6fefce221380/Microsoft.RequirementCategory)
 This is a sample Web Application to use during Continuous Integration demos.
 
 #Build Instruction


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/devuss/25a1e572-fed0-4ac7-a9b2-6b7d6d4b0442/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.